### PR TITLE
 On branch fix_autoremove

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -4,7 +4,7 @@ TTY=$(tty)
 
 IFS="/"
 
-read -r NOTHIN DEV PTS NUM <<< TTY
+read -r NOTHIN DEV PTS NUM <<< $TTY
 
 NEW_PTS=$(($NUM + 1))
 


### PR DESCRIPTION
 Your branch is up to date with 'update_origin/fix_autoremove'.
 Changes to be committed:
	modified:   up.sh

 quick fix: variable TTY was not expanded properly (missing "$") on line
 7